### PR TITLE
New keybinding for inserting <-

### DIFF
--- a/rtichoke/keybinding.py
+++ b/rtichoke/keybinding.py
@@ -219,6 +219,12 @@ def create_keybindings():
         tab_size = event.app.tab_size
         event.current_buffer.insert_text(" " * tab_size)
 
+    # quick ' <- '
+    @handle('-', '-', filter=insert_mode & default_focussed)
+    def _(event):
+        event.current_buffer.insert_text(" <- ")
+        event.current_buffer.cursor_right()
+
     # bracketed paste
     @handle(Keys.BracketedPaste, filter=default_focussed & prompt_mode("r", "browse"))
     def _(event):


### PR DESCRIPTION
Right now it's a pain to type <- in Radian, so here's my Vim key combination for quickly inserting that into code. Notice that it's using a rare R key combo, --. It does not prevent - from being used.

Admittedly you may want to add a user-configurable parameter to enable/disable this mode. I have not done so.

In Rstudio the equivalent key combo is "alt -". You could consider adding that as an option as well.

This is my first pull request ever, so sorry if I've violated some convention.