### PR TITLE
Use .packages(TRUE) to get installed packages for performance

### DIFF
--- a/radian/rutils.py
+++ b/radian/rutils.py
@@ -23,7 +23,7 @@ def package_is_loaded(pkg):
 
 
 def package_is_installed(pkg):
-    return pkg in rcopy(reval("rownames(installed.packages())"))
+    return pkg in rcopy(reval(".packages(TRUE)"))
 
 
 def installed_packages():
@@ -32,7 +32,7 @@ def installed_packages():
         reval(
             """
             tryCatch(
-                base::rownames(utils::installed.packages()),
+                base::.packages(TRUE),
                 error = function(e) character(0)
             )
             """


### PR DESCRIPTION
As we did in https://github.com/REditorSupport/languageserver/pull/204/files#diff-b1c3a3bde5a117d4456cc1f14b375d85R54, `.packages(TRUE)` is a minimal and fastest way to get all installed packages without reading their metadata.