### PR TITLE
Add option for spaces around equals

### DIFF
--- a/radian/completion.py
+++ b/radian/completion.py
@@ -78,7 +78,7 @@ class RCompleter(Completer):
 
         for c in completions:
             if c.startswith(token) and c != token:
-                if c.endswith("="):
+                if c.endswith("=") and settings.add_spaces_around_equals:
                     c = c[:-1] + " = "
                 if c.endswith("::"):
                     # let get_package_completions handles it

--- a/radian/settings.py
+++ b/radian/settings.py
@@ -56,6 +56,7 @@ class RadianSettings(object):
         self._load_setting("vi_mode_prompt", VI_MODE_PROMPT)
         self._load_setting("stderr_format", STDERR_FORMAT)
 
+        self._load_setting("add_spaces_around_equals", True, bool)
         set_width_on_resize = roption("setWidthOnResize", True)
         self._load_setting("auto_width", set_width_on_resize, bool)
 


### PR DESCRIPTION
Hi,

I would like to propose a new option that allows a user to not add spaces around the equals sign for autocompleted arguments. The attached patch is transparent to existing users since the default is to continue adding spaces around the equals sign. This option can be enabled (i.e. suppress adding spaces) in .radian_profile by adding the following lines in ```.radian_profile```:

```
# add space around equals
options(radian.add_space_around_equals = FALSE)
```

Also this is my first patch via git, so apologies if I did not use the correct protocols.

Thanks for this wonderful project.

