### PR TITLE
Add mode-dependent vim cursor to radian/session.py

### DIFF
--- a/radian/session.py
+++ b/radian/session.py
@@ -12,6 +12,8 @@ from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.styles import style_from_pygments_cls
 from prompt_toolkit.utils import is_windows, get_term_environment_variable
+from prompt_toolkit.application.current import get_app
+from prompt_toolkit.key_binding.vi_state import InputMode, ViState
 
 from pygments.styles import get_style_by_name
 
@@ -69,6 +71,32 @@ def apply_settings(session, settings):
     # enables completion of installed package names
     if rcopy(rcall(("utils", "rc.settings"), "ipck")) is None:
         rcall(("utils", "rc.settings"), ipck=True)
+
+    def get_input_mode(self):
+        if sys.version_info[0] == 3:
+            app = get_app()
+            app.ttimeoutlen = 0.01
+            app.timeoutlen = 0.25
+
+        return self._input_mode
+
+    def set_input_mode(self, mode):
+        shape = {InputMode.NAVIGATION: 2, InputMode.REPLACE: 4}.get(mode, 6)
+        cursor = "\x1b[{} q".format(shape)
+
+        if hasattr(sys.stdout, "_cli"):
+            write = sys.stdout._cli.output.write_raw
+        else:
+            write = sys.stdout.write
+
+        write(cursor)
+        sys.stdout.flush()
+
+        self._input_mode = mode
+
+    if session.editing_mode.lower() == "vi":
+        ViState._input_mode = InputMode.INSERT
+        ViState.input_mode = property(get_input_mode, set_input_mode)
 
 
 def create_radian_prompt_session(options, settings):


### PR DESCRIPTION
This pull request demonstrates the vim mode-dependent cursor mentioned (by @petobens) in #153 and requested (by me) in #220.

I put the cursor code into the `apply_settings()` function in `session.py`, but I doubt I picked the right spot on my first try😄

It might be a good idea to have a specific setting for this, but personally I think it is not necessary.