### PR TITLE
Enable autosuggestion from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ options(radian.indent_lines = TRUE)
 # auto match brackets and quotes
 options(radian.auto_match = TRUE)
 
+# disable the [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/master/index.html) [`auto_suggest` feature](https://python-prompt-toolkit.readthedocs.io/en/master/pages/asking_for_input.html#auto-suggestion)
+options(radian.auto_suggest = FALSE)
+
 # highlight matching bracket
 options(radian.highlight_matching_bracket = FALSE)
 

--- a/radian/session.py
+++ b/radian/session.py
@@ -12,6 +12,7 @@ from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.styles import style_from_pygments_cls
 from prompt_toolkit.utils import is_windows, get_term_environment_variable
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 
 from pygments.styles import get_style_by_name
 
@@ -158,7 +159,8 @@ def create_radian_prompt_session(options, settings):
         input=CustomInput(sys.stdin),
         output=output,
         inputhook=get_inputhook(),
-        mode_class=RadianMode
+        mode_class=RadianMode,
+        auto_suggest=AutoSuggestFromHistory()
     )
 
     apply_settings(session, settings)

--- a/radian/session.py
+++ b/radian/session.py
@@ -160,7 +160,7 @@ def create_radian_prompt_session(options, settings):
         output=output,
         inputhook=get_inputhook(),
         mode_class=RadianMode,
-        auto_suggest=AutoSuggestFromHistory() if  settings.auto_suggest else None
+        auto_suggest=AutoSuggestFromHistory() if settings.auto_suggest else None
     )
 
     apply_settings(session, settings)

--- a/radian/session.py
+++ b/radian/session.py
@@ -160,7 +160,7 @@ def create_radian_prompt_session(options, settings):
         output=output,
         inputhook=get_inputhook(),
         mode_class=RadianMode,
-        auto_suggest=AutoSuggestFromHistory()
+        auto_suggest=AutoSuggestFromHistory() if  settings.auto_suggest else None
     )
 
     apply_settings(session, settings)

--- a/radian/settings.py
+++ b/radian/settings.py
@@ -36,6 +36,7 @@ class RadianSettings(object):
         self._settings["prompt"] = prompt
 
     def load(self):
+        self._load_setting("auto_suggest", True, bool)
         self._load_setting("editing_mode", "emacs")
         self._load_setting("color_scheme", "native")
         self._load_setting("auto_match", True, bool)


### PR DESCRIPTION
Autosuggestion is a very useful feature available in fish, zsh, and prompt-toolkit.
In radian, below is a demo of the feature in radian:
1. Start radian
![image](https://user-images.githubusercontent.com/13444106/94687250-055d1d00-02fa-11eb-9a02-45f0f9ea7611.png)
2. Run `print("hello")`
![image](https://user-images.githubusercontent.com/13444106/94687365-29b8f980-02fa-11eb-9533-bd88d0175168.png)
3. Press p to see the autosuggestion
![image](https://user-images.githubusercontent.com/13444106/94687431-3e958d00-02fa-11eb-9ea2-eae27974faa8.png)
4. Press ctrl f, or ctrl e, or right arrow to accept the suggestion
![image](https://user-images.githubusercontent.com/13444106/94687526-608f0f80-02fa-11eb-915a-18b60a487b7d.png)

You can also complete word by word:
1. After starting radian, run `say_hello <- function() {print("hello")}`
![image](https://user-images.githubusercontent.com/13444106/94687917-e3b06580-02fa-11eb-8afa-ef11a9b57c0b.png)
2. Press s
![image](https://user-images.githubusercontent.com/13444106/94687936-ec08a080-02fa-11eb-983c-34be48c07093.png)
3. Press alt f to accept to accept the first word of the suggestion
![image](https://user-images.githubusercontent.com/13444106/94688104-26723d80-02fb-11eb-8cbb-44be86024526.png)

This feature does not interfere with tab completion:
1. After starting radian and running `say_hello <- function() {print("hello")}`, type `say_`
![image](https://user-images.githubusercontent.com/13444106/94688330-6df8c980-02fb-11eb-84f3-9dabc61201be.png)
2A. Press Tab for tab completion
![image](https://user-images.githubusercontent.com/13444106/94688353-7b15b880-02fb-11eb-903e-d787a6894c8e.png)
2B. Press alt f to accept to accept the first word of the suggestion
![image](https://user-images.githubusercontent.com/13444106/94688431-9a144a80-02fb-11eb-9083-490a543e881e.png)
2C. Press ctrl f or ctrl e to accept the entire suggestion
![image](https://user-images.githubusercontent.com/13444106/94688513-b57f5580-02fb-11eb-8f94-207dd79f0ff1.png)

Coexisting with tab completion and accepting suggestions one word at time is important because we may not want the entire line again. Instead, we might only want the function name, so we can add parentheses and call the function.
![image](https://user-images.githubusercontent.com/13444106/94688704-f11a1f80-02fb-11eb-8ec7-c3619193b8e9.png)

To install a version of radian with autosuggestions enabled, run:

`pip install git+https://github.com/mskar/radian@auto_suggest`

Autosuggestions only work in the emacs or vi insert editing modes.
To use autosuggestions in vi insert mode, I created some [custom keybindings](https://github.com/mskar/setup/commit/6abeabe9bcee2f4034cab6b176cc5ce5be034fb0). 

It is possible that some users will not want autosuggestions enabled, so creating a config option for autosuggestions to be used in `.radian_profile` probably is a good idea. 