### PR TITLE
Enable emacs keybindings to vi insert mode

### DIFF
--- a/radian/settings.py
+++ b/radian/settings.py
@@ -37,6 +37,7 @@ class RadianSettings(object):
 
     def load(self):
         self._load_setting("auto_suggest", True, bool)
+        self._load_setting("emacs_bindings_in_vi_insert_mode", True, bool)
         self._load_setting("editing_mode", "emacs")
         self._load_setting("color_scheme", "native")
         self._load_setting("auto_match", True, bool)


### PR DESCRIPTION
# Rationale: 
Emacs keybindings are the default in many UNIX shells (e.g. [`bash` uses GNU `readline`](https://en.m.wikipedia.org/wiki/GNU_Readline#Editing_modes)) and many projects that use prompt_toolkit (including radian), but these bindings are unavailable when vi mode is enabled (e.g. with `set -o vi` in `bash`, `bindkey -v` in `zsh`, or `options(radian.editing_mode = "vi")` in radian).

Not having access to emacs keybindings is a problem for the autosuggestions feature from merged PR #223.

As I described in #223, the emacs bindings `Ctrl-E`, `Ctrl-F`, and `Alt-F` are used to accept autosuggestions. 

Without these bindings, vi editing mode users will have to use the right arrow key to accept autosuggestions.
If there is one that vi users hate... it's using arrow keys.😁

There is a `Condition` called `ebivim` to turn this feature on and off.

Currently, `ebivim` is set to `True` by default to facilitate testing of this feature, but it can be disabled using
```r
options(radian.emacs_bindings_in_vi_insert_mode = False)
```
in `.radian_profile`. 

Some users may want to disable this feature, because it conflicts with one (rather useless) vim insert mode binding: `Ctrl-K`(insert digraph). If anyone needs to use digraphs in radian, they can enter vim by pressing `Ctrl-X`, `Ctrl-E` (assuming `vim` is their `$EDITOR`) and then press `Ctrl-K` followed by the digraph combo (e.g. [`n`, `~` is ñ](https://twitter.com/ben_j_lindsay/status/1310358009936318464?s=20)). 

# Details

This pull request implements the bindings used for accepting autosuggestions, but also many others:
<details><summary>Please click here for the full list of keyboard shortcuts</summary>

- `Alt-B`: move left one word
- `Alt-C`: capitalize word
- `Alt-D`: cut right one word
- `Alt-F`: move right one word
- `Alt-H`: cut left one word
- `Alt-L`: lowercase word
- `Alt-U`: uppercase word
- `Alt-Y`: rotate killring
- `Alt-.`: insert last argument

- `Ctrl-A`: move to line start
- `Ctrl-B`: move left one character
- `Ctrl-D`: cut right one character
- `Ctrl-E`: move to line end
- `Ctrl-F`: move right one character
- `Ctrl-H`: cut left one character
- `Ctrl-K`: cut to line end
- `Ctrl-U`: cut to line start
- `Ctrl-W`: cut left one word
- `Ctrl-Y`: paste
- `Ctrl-_`: undo (in addition to `_`, `-` works too)
- `Ctrl-X`, `Ctrl-E`: edit in `$EDITOR` and execute (also works if `Ctrl` is released after `Ctrl-X`)
</details>

To install a version of radian with autosuggestions enabled, run:

`pip install git+https://github.com/mskar/radian@emacs_bindings_in_vi_insert_mode`