### PR TITLE
EditingMode and InputMode enums handling

### DIFF
--- a/radian/prompt.py
+++ b/radian/prompt.py
@@ -127,8 +127,8 @@ def create_radian_prompt_session(options, settings):
         output = CustomOutput.from_pty(sys.stdout, term=get_term_environment_variable())
 
     def vi_mode_prompt():
-        if str(session.editing_mode).lower() == "vi" and settings.show_vi_mode_prompt:
-            im = session.app.vi_state.input_mode
+        if session.editing_mode == EditingMode.VI and settings.show_vi_mode_prompt:
+            im = session.app.vi_state.input_mode.value
             vi_mode_prompt = settings.vi_mode_prompt
             if isinstance(vi_mode_prompt, str):
                 return vi_mode_prompt.format(str(im)[3:6])
@@ -145,7 +145,7 @@ def create_radian_prompt_session(options, settings):
             return session._prompt_message
 
     if settings.editing_mode in ["vim", "vi"]:
-        editing_mode = EditingMode.Vi
+        editing_mode = EditingMode.VI
     else:
         editing_mode = EditingMode.EMACS
 


### PR DESCRIPTION
It seems vi mode was not working in 0.6, although I'm not entirely clear why.

The main thing is that radian wouldn't start because EditingMode.Vi doesn't exist. I guess lineedit was replaced by prompt-toolkit here, but lineedit also defines EditingMode.VI, not EditingMode.Vi.

Then in vi_mode_prompt, the code was expecting editing_mode and input_mode to be their values rather than their 'key' (that is, 'VI' rather than EditingMode.VI and 'vi-insert' rather than InputMode.INSERT). The code in 0.5 before the introduction of prompt.py is pretty much the same though, so I don't see what would lead to a different behavior.