### PR TITLE
only wrap text if the line length > 1000

### DIFF
--- a/radian/rutils.py
+++ b/radian/rutils.py
@@ -5,6 +5,16 @@ from rchitect.interface import roption
 from .key_bindings import map_key
 
 
+def is_long_non_ascii_multiline(text):
+    if text.isascii():
+        return False
+    if "\n" not in text:
+        return False
+    if len(text) < 1000:
+        return False
+    return True
+
+
 def package_is_loaded(pkg):
     return pkg in rcopy(rcall(("base", "loadedNamespaces")))
 


### PR DESCRIPTION
fix #388

A bit of background.
To order to fix #379, we have to wrap the input by `{` and `}` in order to correctly handle long non-ascii multiline strings. The hack is needed due to R's read console restriction. R is only capable of reading 4096 bytes per line and non-ascii chars cannot be split in middle. 

A simple fix for now is to only wrap the input has > 1000 chars and there is a non-ascii text somewhere in the input. A better solution down the road is to detect exactly where the long mutliline strings are and break the strings manually.