### PR TITLE
Use simple ascii check instead

### DIFF
--- a/radian/rutils.py
+++ b/radian/rutils.py
@@ -5,7 +5,12 @@ from rchitect.interface import roption
 from .key_bindings import map_key
 
 def is_ascii(str):
-    return all(ord(c) < 128 for c in str)
+    try:
+        str.decode('ascii')
+    except UnicodeDecodeError:
+        return False
+    else:
+        return True
 
 def is_long_non_ascii_multiline(text):
     if is_ascii(text):

--- a/radian/rutils.py
+++ b/radian/rutils.py
@@ -4,9 +4,11 @@ from rchitect import rcopy, reval, rcall
 from rchitect.interface import roption
 from .key_bindings import map_key
 
+def is_ascii(str):
+    return all(ord(c) < 128 for c in str)
 
 def is_long_non_ascii_multiline(text):
-    if text.isascii():
+    if is_ascii(text):
         return False
     if "\n" not in text:
         return False

--- a/radian/rutils.py
+++ b/radian/rutils.py
@@ -5,12 +5,7 @@ from rchitect.interface import roption
 from .key_bindings import map_key
 
 def is_ascii(str):
-    try:
-        str.decode('ascii')
-    except UnicodeDecodeError:
-        return False
-    else:
-        return True
+    return all(ord(c) < 128 for c in str)
 
 def is_long_non_ascii_multiline(text):
     if is_ascii(text):


### PR DESCRIPTION
`str.decode()` still does not work in Python 3.6. Use simple ascii check instead.