### PR TITLE
Instructions for vim-slime

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ let R_bracketed_paste = 1
 ```
 in your vim config. 
 
+#### [vim-slime](https://github.com/jpalardy/vim-slime) support
+
+In case you use vim-slime or similar programs to send the code to radian REPL directly from the text editor, put `options(radian.auto_match = FALSE)` in [your profile file](https://github.com/randy3k/radian#settings) to avoid radian autocompletion of a code line that will be completed in the subsequent lines.
+
 
 #### `reticulate` Auto Completions
 


### PR DESCRIPTION
Using the default settings, if for example you send
```
print(
"hello"
)
```
over, it will send `print(` and radian will complete it to `print()` and run it. The other two lines will be invalid.