### PR TITLE
Update message locale for `test_early_termination`

### DIFF
--- a/tests/test_readline.py
+++ b/tests/test_readline.py
@@ -62,7 +62,7 @@ def test_strings_bracketed(terminal):
 
 def test_early_termination(terminal):
     terminal.current_line().assert_startswith("r$>")
-    terminal.write("stop('!')\x1b\rd = 1\n")
+    terminal.write("Sys.setlocale(category = 'LC_MESSAGES', locale = 'en_US.UTF8'); stop('!')\x1b\rd = 1\n")
     terminal.previous_line(2).assert_startswith("Error")
     terminal.write("d\n")
     terminal.previous_line(2).assert_startswith("Error: object 'd' not found")


### PR DESCRIPTION
The `test_early_termination` test from `test_readline.py` causes an error if the locale is other than English. This is important for the AUR package as you cannot install radian from the AUR without all the tests passing. This commit adds an explicit locale change for messages set before executing `stop('!')` making sure the error message would be indeed `Error:` and not e.g. `BŁĄD:`.